### PR TITLE
Update format test to get correct references with develop, and update for new hdf5 versions.

### DIFF
--- a/api/check_api.sh
+++ b/api/check_api.sh
@@ -115,7 +115,7 @@ CHECK()
             else
                 echo "*FAILED*"
                 echo "!!! Error: There was an error running this test !!!"
-                echo " The file containing expected output did not exist"
+                echo " The file $expected containing expected output did not exist"
                 echo
 
                 CLEANUP
@@ -198,8 +198,8 @@ TEST()
     TESTING "normal 1.12.x library build"
     BUILD "$h5cc112 $compile_options" $testname "v112-actual"
 
-    TESTING "normal 1.13.x library build"
-    BUILD "$h5ccdev $compile_options" $testname "vdev-actual"
+    TESTING "normal 1.14.x library build"
+    BUILD "$h5cc114 $compile_options" $testname "v114-actual"
 
     TESTING "1.8.x library built in 1.6.x compatibility mode"
     BUILD "$h5cc18compat $compile_options" $testname "v18-compat"
@@ -237,28 +237,52 @@ TEST()
     TESTING "normal 1.12.x library build, with 1.10.x compatibility macro"
     BUILD "$h5cc112 -DH5_USE_110_API $compile_options" $testname "v112-110macro"
 
-    TESTING "1.13.x library built in 1.6.x compatibility mode"
+    TESTING "1.14.x library built in 1.6.x compatibility mode"
+    BUILD "$h5cc114compat16 $compile_options" $testname "v114-16compat"
+
+    TESTING "normal 1.14.x library build, with 1.6.x compatibility macro"
+    BUILD "$h5cc114 -DH5_USE_16_API $compile_options" $testname "v114-16macro"
+
+    TESTING "1.14.x library built in 1.8.x compatibility mode"
+    BUILD "$h5cc114compat18 $compile_options" $testname "v114-18compat"
+
+    TESTING "normal 1.14.x library build, with 1.8.x compatibility macro"
+    BUILD "$h5cc114 -DH5_USE_18_API $compile_options" $testname "v114-18macro"
+
+    TESTING "1.14.x library built in 1.10.x compatibility mode"
+    BUILD "$h5cc114compat110 $compile_options" $testname "v114-110compat"
+
+    TESTING "normal 1.14.x library build, with 1.10.x compatibility macro"
+    BUILD "$h5cc114 -DH5_USE_110_API $compile_options" $testname "v114-110macro"
+
+    TESTING "1.14.x library built in 1.12.x compatibility mode"
+    BUILD "$h5cc114compat112 $compile_options" $testname "v114-112compat"
+
+    TESTING "normal 1.14.x library build, with 1.12.x compatibility macro"
+    BUILD "$h5cc114 -DH5_USE_112_API $compile_options" $testname "v114-112macro"
+
+    TESTING "1.15.x library built in 1.6.x compatibility mode"
     BUILD "$h5ccdevcompat16 $compile_options" $testname "vdev-16compat"
 
-    TESTING "normal 1.13.x library build, with 1.6.x compatibility macro"
+    TESTING "normal 1.15.x library build, with 1.6.x compatibility macro"
     BUILD "$h5ccdev -DH5_USE_16_API $compile_options" $testname "vdev-16macro"
 
-    TESTING "1.13.x library built in 1.8.x compatibility mode"
+    TESTING "1.15.x library built in 1.8.x compatibility mode"
     BUILD "$h5ccdevcompat18 $compile_options" $testname "vdev-18compat"
 
-    TESTING "normal 1.13.x library build, with 1.8.x compatibility macro"
+    TESTING "normal 1.15.x library build, with 1.8.x compatibility macro"
     BUILD "$h5ccdev -DH5_USE_18_API $compile_options" $testname "vdev-18macro"
 
-    TESTING "1.13.x library built in 1.10.x compatibility mode"
+    TESTING "1.15.x library built in 1.10.x compatibility mode"
     BUILD "$h5ccdevcompat110 $compile_options" $testname "vdev-110compat"
 
-    TESTING "normal 1.13.x library build, with 1.10.x compatibility macro"
+    TESTING "normal 1.15.x library build, with 1.10.x compatibility macro"
     BUILD "$h5ccdev -DH5_USE_110_API $compile_options" $testname "vdev-110macro"
 
-    TESTING "1.13.x library built in 1.12.x compatibility mode"
+    TESTING "1.15.x library built in 1.12.x compatibility mode"
     BUILD "$h5ccdevcompat112 $compile_options" $testname "vdev-112compat"
 
-    TESTING "normal 1.13.x library build, with 1.12.x compatibility macro"
+    TESTING "normal 1.15.x library build, with 1.12.x compatibility macro"
     BUILD "$h5ccdev -DH5_USE_112_API $compile_options" $testname "vdev-112macro"
 }
 
@@ -307,6 +331,20 @@ TESTAPI112()
 # Build test program with different API routine versions overridden
 #
 TESTAPI114()
+{
+    # Create aliases for the parameters
+    testname=$1
+    compile_options=$2
+    suffix=$3
+    compat_options=$4
+
+    TESTING "normal 1.14.x, with: $compat_options"
+    BUILD "$h5cc114 $compat_options $compile_options" $testname "v114-$suffix"
+}
+
+# Build test program with different API routine versions overridden
+#
+TESTAPI116()
 {
     # Create aliases for the parameters
     testname=$1
@@ -573,6 +611,11 @@ h5ccdevcompat16="/mnt/scr1/pre-release/hdf5/vdev/compat16/$HOST_NAME/bin/h5cc"
 h5ccdevcompat18="/mnt/scr1/pre-release/hdf5/vdev/compat18/$HOST_NAME/bin/h5cc"
 h5ccdevcompat110="/mnt/scr1/pre-release/hdf5/vdev/compat110/$HOST_NAME/bin/h5cc"
 h5ccdevcompat112="/mnt/scr1/pre-release/hdf5/vdev/compat112/$HOST_NAME/bin/h5cc"
+h5cc114="/mnt/scr1/pre-release/hdf5/v114/$HOST_NAME/bin/h5cc"
+h5cc114compat16="/mnt/scr1/pre-release/hdf5/v114/compat16/$HOST_NAME/bin/h5cc"
+h5cc114compat18="/mnt/scr1/pre-release/hdf5/v114/compat18/$HOST_NAME/bin/h5cc"
+h5cc114compat110="/mnt/scr1/pre-release/hdf5/v114/compat110/$HOST_NAME/bin/h5cc"
+h5cc114compat112="/mnt/scr1/pre-release/hdf5/v114/compat112/$HOST_NAME/bin/h5cc"
 h5cc112="/mnt/scr1/pre-release/hdf5/v112/$HOST_NAME/bin/h5cc"
 h5cc112compat16="/mnt/scr1/pre-release/hdf5/v112/compat16/$HOST_NAME/bin/h5cc"
 h5cc112compat18="/mnt/scr1/pre-release/hdf5/v112/compat18/$HOST_NAME/bin/h5cc"
@@ -631,12 +674,33 @@ if [ ! -x $h5ccdevcompat16 ]; then
     exit 1
 fi
 
+if [ ! -x $h5cc114 ]; then
+    echo "h5cc114($h5cc114) not found or not executable.  Abort"
+    exit 1
+fi
+if [ ! -x $h5cc114compat112 ]; then
+    echo "h5cc114compat112($h5cc114compat112) not found or not executable.  Abort"
+    exit 1
+fi
+if [ ! -x $h5cc114compat110 ]; then
+    echo "h5cc114compat110($h5cc114compat110) not found or not executable.  Abort"
+    exit 1
+fi
+if [ ! -x $h5cc114compat18 ]; then
+    echo "h5cc114compat18($h5cc114compat18) not found or not executable.  Abort"
+    exit 1
+fi
+if [ ! -x $h5cc114compat16 ]; then
+    echo "h5cc114compat16($h5cc114compat16) not found or not executable.  Abort"
+    exit 1
+fi
+
 if [ ! -x $h5cc112 ]; then
     echo "h5cc112($h5cc112) not found or not executable.  Abort"
     exit 1
 fi
-if [ ! -x $h5ccdevcompat112 ]; then
-    echo "h5ccdevcompat112($h5ccdevcompat112) not found or not executable.  Abort"
+if [ ! -x $h5cc112compat110 ]; then
+    echo "h5cc112compat110($h5cc112compat110) not found or not executable.  Abort"
     exit 1
 fi
 if [ ! -x $h5cc112compat18 ]; then
@@ -682,6 +746,11 @@ echo "h5ccdevcompat112 = $h5ccdevcompat112"
 echo "h5ccdevcompat110 = $h5ccdevcompat110"
 echo "h5ccdevcompat18 = $h5ccdevcompat18"
 echo "h5ccdevcompat16 = $h5ccdevcompat16"
+echo "h5cc114 = $h5cc114"
+echo "h5cc114compat112 = $h5cc114compat112"
+echo "h5cc114compat110 = $h5cc114compat110"
+echo "h5cc114compat18 = $h5cc114compat18"
+echo "h5cc114compat16 = $h5cc114compat16"
 echo "h5cc112 = $h5cc112"
 echo "h5cc112compat110 = $h5cc112compat110"
 echo "h5cc112compat18 = $h5cc112compat18"

--- a/api/expected/test_h5a/v114-110compat
+++ b/api/expected/test_h5a/v114-110compat
@@ -1,0 +1,2 @@
+H5Acreate_vers = 2
+H5Aiterate_vers = 2

--- a/api/expected/test_h5a/v114-110macro
+++ b/api/expected/test_h5a/v114-110macro
@@ -1,0 +1,2 @@
+H5Acreate_vers = 2
+H5Aiterate_vers = 2

--- a/api/expected/test_h5a/v114-112compat
+++ b/api/expected/test_h5a/v114-112compat
@@ -1,0 +1,2 @@
+H5Acreate_vers = 2
+H5Aiterate_vers = 2

--- a/api/expected/test_h5a/v114-112macro
+++ b/api/expected/test_h5a/v114-112macro
@@ -1,0 +1,2 @@
+H5Acreate_vers = 2
+H5Aiterate_vers = 2

--- a/api/expected/test_h5a/v114-16compat
+++ b/api/expected/test_h5a/v114-16compat
@@ -1,0 +1,2 @@
+H5Acreate_vers = 1
+H5Aiterate_vers = 1

--- a/api/expected/test_h5a/v114-16macro
+++ b/api/expected/test_h5a/v114-16macro
@@ -1,0 +1,2 @@
+H5Acreate_vers = 1
+H5Aiterate_vers = 1

--- a/api/expected/test_h5a/v114-18compat
+++ b/api/expected/test_h5a/v114-18compat
@@ -1,0 +1,2 @@
+H5Acreate_vers = 2
+H5Aiterate_vers = 2

--- a/api/expected/test_h5a/v114-18macro
+++ b/api/expected/test_h5a/v114-18macro
@@ -1,0 +1,2 @@
+H5Acreate_vers = 2
+H5Aiterate_vers = 2

--- a/api/expected/test_h5a/v114-actual
+++ b/api/expected/test_h5a/v114-actual
@@ -1,0 +1,2 @@
+H5Acreate_vers = 2
+H5Aiterate_vers = 2

--- a/api/expected/test_h5d/v114-110compat
+++ b/api/expected/test_h5d/v114-110compat
@@ -1,0 +1,2 @@
+H5Dcreate_vers = 2
+H5Dopen_vers = 2

--- a/api/expected/test_h5d/v114-110macro
+++ b/api/expected/test_h5d/v114-110macro
@@ -1,0 +1,2 @@
+H5Dcreate_vers = 2
+H5Dopen_vers = 2

--- a/api/expected/test_h5d/v114-112compat
+++ b/api/expected/test_h5d/v114-112compat
@@ -1,0 +1,2 @@
+H5Dcreate_vers = 2
+H5Dopen_vers = 2

--- a/api/expected/test_h5d/v114-112macro
+++ b/api/expected/test_h5d/v114-112macro
@@ -1,0 +1,2 @@
+H5Dcreate_vers = 2
+H5Dopen_vers = 2

--- a/api/expected/test_h5d/v114-16compat
+++ b/api/expected/test_h5d/v114-16compat
@@ -1,0 +1,2 @@
+H5Dcreate_vers = 1
+H5Dopen_vers = 1

--- a/api/expected/test_h5d/v114-16macro
+++ b/api/expected/test_h5d/v114-16macro
@@ -1,0 +1,2 @@
+H5Dcreate_vers = 1
+H5Dopen_vers = 1

--- a/api/expected/test_h5d/v114-18compat
+++ b/api/expected/test_h5d/v114-18compat
@@ -1,0 +1,2 @@
+H5Dcreate_vers = 2
+H5Dopen_vers = 2

--- a/api/expected/test_h5d/v114-18macro
+++ b/api/expected/test_h5d/v114-18macro
@@ -1,0 +1,2 @@
+H5Dcreate_vers = 2
+H5Dopen_vers = 2

--- a/api/expected/test_h5d/v114-actual
+++ b/api/expected/test_h5d/v114-actual
@@ -1,0 +1,2 @@
+H5Dcreate_vers = 2
+H5Dopen_vers = 2

--- a/api/expected/test_h5e/v114-110compat
+++ b/api/expected/test_h5e/v114-110compat
@@ -1,0 +1,7 @@
+H5E_auto_t_vers = 2
+H5Eclear_vers = 2
+H5Eget_auto_vers = 2
+H5Eprint_vers = 2
+H5Epush_vers = 2
+H5Eset_auto_vers = 2
+H5Ewalk_vers = 2

--- a/api/expected/test_h5e/v114-110macro
+++ b/api/expected/test_h5e/v114-110macro
@@ -1,0 +1,7 @@
+H5E_auto_t_vers = 2
+H5Eclear_vers = 2
+H5Eget_auto_vers = 2
+H5Eprint_vers = 2
+H5Epush_vers = 2
+H5Eset_auto_vers = 2
+H5Ewalk_vers = 2

--- a/api/expected/test_h5e/v114-112compat
+++ b/api/expected/test_h5e/v114-112compat
@@ -1,0 +1,7 @@
+H5E_auto_t_vers = 2
+H5Eclear_vers = 2
+H5Eget_auto_vers = 2
+H5Eprint_vers = 2
+H5Epush_vers = 2
+H5Eset_auto_vers = 2
+H5Ewalk_vers = 2

--- a/api/expected/test_h5e/v114-112macro
+++ b/api/expected/test_h5e/v114-112macro
@@ -1,0 +1,7 @@
+H5E_auto_t_vers = 2
+H5Eclear_vers = 2
+H5Eget_auto_vers = 2
+H5Eprint_vers = 2
+H5Epush_vers = 2
+H5Eset_auto_vers = 2
+H5Ewalk_vers = 2

--- a/api/expected/test_h5e/v114-16compat
+++ b/api/expected/test_h5e/v114-16compat
@@ -1,0 +1,7 @@
+H5E_auto_t_vers = 1
+H5Eclear_vers = 1
+H5Eget_auto_vers = 1
+H5Eprint_vers = 1
+H5Epush_vers = 1
+H5Eset_auto_vers = 1
+H5Ewalk_vers = 1

--- a/api/expected/test_h5e/v114-16macro
+++ b/api/expected/test_h5e/v114-16macro
@@ -1,0 +1,7 @@
+H5E_auto_t_vers = 1
+H5Eclear_vers = 1
+H5Eget_auto_vers = 1
+H5Eprint_vers = 1
+H5Epush_vers = 1
+H5Eset_auto_vers = 1
+H5Ewalk_vers = 1

--- a/api/expected/test_h5e/v114-18compat
+++ b/api/expected/test_h5e/v114-18compat
@@ -1,0 +1,7 @@
+H5E_auto_t_vers = 2
+H5Eclear_vers = 2
+H5Eget_auto_vers = 2
+H5Eprint_vers = 2
+H5Epush_vers = 2
+H5Eset_auto_vers = 2
+H5Ewalk_vers = 2

--- a/api/expected/test_h5e/v114-18macro
+++ b/api/expected/test_h5e/v114-18macro
@@ -1,0 +1,7 @@
+H5E_auto_t_vers = 2
+H5Eclear_vers = 2
+H5Eget_auto_vers = 2
+H5Eprint_vers = 2
+H5Epush_vers = 2
+H5Eset_auto_vers = 2
+H5Ewalk_vers = 2

--- a/api/expected/test_h5e/v114-actual
+++ b/api/expected/test_h5e/v114-actual
@@ -1,0 +1,7 @@
+H5E_auto_t_vers = 2
+H5Eclear_vers = 2
+H5Eget_auto_vers = 2
+H5Eprint_vers = 2
+H5Epush_vers = 2
+H5Eset_auto_vers = 2
+H5Ewalk_vers = 2

--- a/api/expected/test_h5f/v114-110compat
+++ b/api/expected/test_h5f/v114-110compat
@@ -1,0 +1,1 @@
+H5Fget_info_vers = 2

--- a/api/expected/test_h5f/v114-110macro
+++ b/api/expected/test_h5f/v114-110macro
@@ -1,0 +1,1 @@
+H5Fget_info_vers = 2

--- a/api/expected/test_h5f/v114-112compat
+++ b/api/expected/test_h5f/v114-112compat
@@ -1,0 +1,1 @@
+H5Fget_info_vers = 2

--- a/api/expected/test_h5f/v114-112macro
+++ b/api/expected/test_h5f/v114-112macro
@@ -1,0 +1,1 @@
+H5Fget_info_vers = 2

--- a/api/expected/test_h5f/v114-16compat
+++ b/api/expected/test_h5f/v114-16compat
@@ -1,0 +1,1 @@
+H5Fget_info_vers = 2

--- a/api/expected/test_h5f/v114-16macro
+++ b/api/expected/test_h5f/v114-16macro
@@ -1,0 +1,1 @@
+H5Fget_info_vers = 2

--- a/api/expected/test_h5f/v114-18compat
+++ b/api/expected/test_h5f/v114-18compat
@@ -1,0 +1,1 @@
+H5Fget_info_vers = 1

--- a/api/expected/test_h5f/v114-18macro
+++ b/api/expected/test_h5f/v114-18macro
@@ -1,0 +1,1 @@
+H5Fget_info_vers = 1

--- a/api/expected/test_h5f/v114-actual
+++ b/api/expected/test_h5f/v114-actual
@@ -1,0 +1,1 @@
+H5Fget_info_vers = 2

--- a/api/expected/test_h5g/v114-110compat
+++ b/api/expected/test_h5g/v114-110compat
@@ -1,0 +1,2 @@
+H5Gcreate_vers = 2
+H5Gopen_vers = 2

--- a/api/expected/test_h5g/v114-110macro
+++ b/api/expected/test_h5g/v114-110macro
@@ -1,0 +1,2 @@
+H5Gcreate_vers = 2
+H5Gopen_vers = 2

--- a/api/expected/test_h5g/v114-112compat
+++ b/api/expected/test_h5g/v114-112compat
@@ -1,0 +1,2 @@
+H5Gcreate_vers = 2
+H5Gopen_vers = 2

--- a/api/expected/test_h5g/v114-112macro
+++ b/api/expected/test_h5g/v114-112macro
@@ -1,0 +1,2 @@
+H5Gcreate_vers = 2
+H5Gopen_vers = 2

--- a/api/expected/test_h5g/v114-16compat
+++ b/api/expected/test_h5g/v114-16compat
@@ -1,0 +1,2 @@
+H5Gcreate_vers = 1
+H5Gopen_vers = 1

--- a/api/expected/test_h5g/v114-16macro
+++ b/api/expected/test_h5g/v114-16macro
@@ -1,0 +1,2 @@
+H5Gcreate_vers = 1
+H5Gopen_vers = 1

--- a/api/expected/test_h5g/v114-18compat
+++ b/api/expected/test_h5g/v114-18compat
@@ -1,0 +1,2 @@
+H5Gcreate_vers = 2
+H5Gopen_vers = 2

--- a/api/expected/test_h5g/v114-18macro
+++ b/api/expected/test_h5g/v114-18macro
@@ -1,0 +1,2 @@
+H5Gcreate_vers = 2
+H5Gopen_vers = 2

--- a/api/expected/test_h5g/v114-actual
+++ b/api/expected/test_h5g/v114-actual
@@ -1,0 +1,2 @@
+H5Gcreate_vers = 2
+H5Gopen_vers = 2

--- a/api/expected/test_h5o/v114-110compat
+++ b/api/expected/test_h5o/v114-110compat
@@ -1,0 +1,5 @@
+H5Oget_info_vers = 1
+H5Oget_info_by_name_vers = 1
+H5Oget_info_by_idx_vers = 1
+H5Ovisit_vers = 1
+H5Ovisit_by_name_vers = 1

--- a/api/expected/test_h5o/v114-110macro
+++ b/api/expected/test_h5o/v114-110macro
@@ -1,0 +1,5 @@
+H5Oget_info_vers = 1
+H5Oget_info_by_name_vers = 1
+H5Oget_info_by_idx_vers = 1
+H5Ovisit_vers = 1
+H5Ovisit_by_name_vers = 1

--- a/api/expected/test_h5o/v114-112compat
+++ b/api/expected/test_h5o/v114-112compat
@@ -1,0 +1,5 @@
+H5Oget_info_vers = 3
+H5Oget_info_by_name_vers = 3
+H5Oget_info_by_idx_vers = 3
+H5Ovisit_vers = 3
+H5Ovisit_by_name_vers = 3

--- a/api/expected/test_h5o/v114-112macro
+++ b/api/expected/test_h5o/v114-112macro
@@ -1,0 +1,5 @@
+H5Oget_info_vers = 3
+H5Oget_info_by_name_vers = 3
+H5Oget_info_by_idx_vers = 3
+H5Ovisit_vers = 3
+H5Ovisit_by_name_vers = 3

--- a/api/expected/test_h5o/v114-16compat
+++ b/api/expected/test_h5o/v114-16compat
@@ -1,0 +1,5 @@
+H5Oget_info_vers = 3
+H5Oget_info_by_name_vers = 3
+H5Oget_info_by_idx_vers = 3
+H5Ovisit_vers = 3
+H5Ovisit_by_name_vers = 3

--- a/api/expected/test_h5o/v114-16macro
+++ b/api/expected/test_h5o/v114-16macro
@@ -1,0 +1,5 @@
+H5Oget_info_vers = 3
+H5Oget_info_by_name_vers = 3
+H5Oget_info_by_idx_vers = 3
+H5Ovisit_vers = 3
+H5Ovisit_by_name_vers = 3

--- a/api/expected/test_h5o/v114-18compat
+++ b/api/expected/test_h5o/v114-18compat
@@ -1,0 +1,5 @@
+H5Oget_info_vers = 1
+H5Oget_info_by_name_vers = 1
+H5Oget_info_by_idx_vers = 1
+H5Ovisit_vers = 1
+H5Ovisit_by_name_vers = 1

--- a/api/expected/test_h5o/v114-18macro
+++ b/api/expected/test_h5o/v114-18macro
@@ -1,0 +1,5 @@
+H5Oget_info_vers = 1
+H5Oget_info_by_name_vers = 1
+H5Oget_info_by_idx_vers = 1
+H5Ovisit_vers = 1
+H5Ovisit_by_name_vers = 1

--- a/api/expected/test_h5o/v114-actual
+++ b/api/expected/test_h5o/v114-actual
@@ -1,0 +1,5 @@
+H5Oget_info_vers = 3
+H5Oget_info_by_name_vers = 3
+H5Oget_info_by_idx_vers = 3
+H5Ovisit_vers = 3
+H5Ovisit_by_name_vers = 3

--- a/api/expected/test_h5p/v114-110compat
+++ b/api/expected/test_h5p/v114-110compat
@@ -1,0 +1,5 @@
+H5Pget_filter_vers = 2
+H5Pget_filter_by_id_vers = 2
+H5Pinsert_vers = 2
+H5Pregister_vers = 2
+H5Pencode_vers = 1

--- a/api/expected/test_h5p/v114-110macro
+++ b/api/expected/test_h5p/v114-110macro
@@ -1,0 +1,5 @@
+H5Pget_filter_vers = 2
+H5Pget_filter_by_id_vers = 2
+H5Pinsert_vers = 2
+H5Pregister_vers = 2
+H5Pencode_vers = 1

--- a/api/expected/test_h5p/v114-112compat
+++ b/api/expected/test_h5p/v114-112compat
@@ -1,0 +1,5 @@
+H5Pget_filter_vers = 2
+H5Pget_filter_by_id_vers = 2
+H5Pinsert_vers = 2
+H5Pregister_vers = 2
+H5Pencode_vers = 2

--- a/api/expected/test_h5p/v114-112macro
+++ b/api/expected/test_h5p/v114-112macro
@@ -1,0 +1,5 @@
+H5Pget_filter_vers = 2
+H5Pget_filter_by_id_vers = 2
+H5Pinsert_vers = 2
+H5Pregister_vers = 2
+H5Pencode_vers = 2

--- a/api/expected/test_h5p/v114-16compat
+++ b/api/expected/test_h5p/v114-16compat
@@ -1,0 +1,5 @@
+H5Pget_filter_vers = 1
+H5Pget_filter_by_id_vers = 1
+H5Pinsert_vers = 1
+H5Pregister_vers = 1
+H5Pencode_vers = 2

--- a/api/expected/test_h5p/v114-16macro
+++ b/api/expected/test_h5p/v114-16macro
@@ -1,0 +1,5 @@
+H5Pget_filter_vers = 1
+H5Pget_filter_by_id_vers = 1
+H5Pinsert_vers = 1
+H5Pregister_vers = 1
+H5Pencode_vers = 2

--- a/api/expected/test_h5p/v114-18compat
+++ b/api/expected/test_h5p/v114-18compat
@@ -1,0 +1,5 @@
+H5Pget_filter_vers = 2
+H5Pget_filter_by_id_vers = 2
+H5Pinsert_vers = 2
+H5Pregister_vers = 2
+H5Pencode_vers = 2

--- a/api/expected/test_h5p/v114-18macro
+++ b/api/expected/test_h5p/v114-18macro
@@ -1,0 +1,5 @@
+H5Pget_filter_vers = 2
+H5Pget_filter_by_id_vers = 2
+H5Pinsert_vers = 2
+H5Pregister_vers = 2
+H5Pencode_vers = 2

--- a/api/expected/test_h5p/v114-actual
+++ b/api/expected/test_h5p/v114-actual
@@ -1,0 +1,5 @@
+H5Pget_filter_vers = 2
+H5Pget_filter_by_id_vers = 2
+H5Pinsert_vers = 2
+H5Pregister_vers = 2
+H5Pencode_vers = 2

--- a/api/expected/test_h5r/v114-110compat
+++ b/api/expected/test_h5r/v114-110compat
@@ -1,0 +1,2 @@
+H5Rget_obj_type_vers = 2
+H5Rdereference_vers = 2

--- a/api/expected/test_h5r/v114-110macro
+++ b/api/expected/test_h5r/v114-110macro
@@ -1,0 +1,2 @@
+H5Rget_obj_type_vers = 2
+H5Rdereference_vers = 2

--- a/api/expected/test_h5r/v114-112compat
+++ b/api/expected/test_h5r/v114-112compat
@@ -1,0 +1,2 @@
+H5Rget_obj_type_vers = 2
+H5Rdereference_vers = 2

--- a/api/expected/test_h5r/v114-112macro
+++ b/api/expected/test_h5r/v114-112macro
@@ -1,0 +1,2 @@
+H5Rget_obj_type_vers = 2
+H5Rdereference_vers = 2

--- a/api/expected/test_h5r/v114-16compat
+++ b/api/expected/test_h5r/v114-16compat
@@ -1,0 +1,2 @@
+H5Rget_obj_type_vers = 1
+H5Rdereference_vers = 1

--- a/api/expected/test_h5r/v114-16macro
+++ b/api/expected/test_h5r/v114-16macro
@@ -1,0 +1,2 @@
+H5Rget_obj_type_vers = 1
+H5Rdereference_vers = 1

--- a/api/expected/test_h5r/v114-18compat
+++ b/api/expected/test_h5r/v114-18compat
@@ -1,0 +1,2 @@
+H5Rget_obj_type_vers = 2
+H5Rdereference_vers = 1

--- a/api/expected/test_h5r/v114-18macro
+++ b/api/expected/test_h5r/v114-18macro
@@ -1,0 +1,2 @@
+H5Rget_obj_type_vers = 2
+H5Rdereference_vers = 1

--- a/api/expected/test_h5r/v114-actual
+++ b/api/expected/test_h5r/v114-actual
@@ -1,0 +1,2 @@
+H5Rget_obj_type_vers = 2
+H5Rdereference_vers = 2

--- a/api/expected/test_h5s/v114-110compat
+++ b/api/expected/test_h5s/v114-110compat
@@ -1,0 +1,1 @@
+H5Sencode_vers = 1

--- a/api/expected/test_h5s/v114-110macro
+++ b/api/expected/test_h5s/v114-110macro
@@ -1,0 +1,1 @@
+H5Sencode_vers = 1

--- a/api/expected/test_h5s/v114-112compat
+++ b/api/expected/test_h5s/v114-112compat
@@ -1,0 +1,1 @@
+H5Sencode_vers = 2

--- a/api/expected/test_h5s/v114-112macro
+++ b/api/expected/test_h5s/v114-112macro
@@ -1,0 +1,1 @@
+H5Sencode_vers = 2

--- a/api/expected/test_h5s/v114-16compat
+++ b/api/expected/test_h5s/v114-16compat
@@ -1,0 +1,1 @@
+H5Sencode_vers = 2

--- a/api/expected/test_h5s/v114-16macro
+++ b/api/expected/test_h5s/v114-16macro
@@ -1,0 +1,1 @@
+H5Sencode_vers = 2

--- a/api/expected/test_h5s/v114-18compat
+++ b/api/expected/test_h5s/v114-18compat
@@ -1,0 +1,1 @@
+H5Sencode_vers = 1

--- a/api/expected/test_h5s/v114-18macro
+++ b/api/expected/test_h5s/v114-18macro
@@ -1,0 +1,1 @@
+H5Sencode_vers = 1

--- a/api/expected/test_h5s/v114-actual
+++ b/api/expected/test_h5s/v114-actual
@@ -1,0 +1,1 @@
+H5Sencode_vers = 2

--- a/api/expected/test_h5t/v114-110compat
+++ b/api/expected/test_h5t/v114-110compat
@@ -1,0 +1,4 @@
+H5Tarray_create_vers = 2
+H5Tcommit_vers = 2
+H5Tget_array_dims_vers = 2
+H5Topen_vers = 2

--- a/api/expected/test_h5t/v114-110macro
+++ b/api/expected/test_h5t/v114-110macro
@@ -1,0 +1,4 @@
+H5Tarray_create_vers = 2
+H5Tcommit_vers = 2
+H5Tget_array_dims_vers = 2
+H5Topen_vers = 2

--- a/api/expected/test_h5t/v114-112compat
+++ b/api/expected/test_h5t/v114-112compat
@@ -1,0 +1,4 @@
+H5Tarray_create_vers = 2
+H5Tcommit_vers = 2
+H5Tget_array_dims_vers = 2
+H5Topen_vers = 2

--- a/api/expected/test_h5t/v114-112macro
+++ b/api/expected/test_h5t/v114-112macro
@@ -1,0 +1,4 @@
+H5Tarray_create_vers = 2
+H5Tcommit_vers = 2
+H5Tget_array_dims_vers = 2
+H5Topen_vers = 2

--- a/api/expected/test_h5t/v114-16compat
+++ b/api/expected/test_h5t/v114-16compat
@@ -1,0 +1,4 @@
+H5Tarray_create_vers = 1
+H5Tcommit_vers = 1
+H5Tget_array_dims_vers = 1
+H5Topen_vers = 1

--- a/api/expected/test_h5t/v114-16macro
+++ b/api/expected/test_h5t/v114-16macro
@@ -1,0 +1,4 @@
+H5Tarray_create_vers = 1
+H5Tcommit_vers = 1
+H5Tget_array_dims_vers = 1
+H5Topen_vers = 1

--- a/api/expected/test_h5t/v114-18compat
+++ b/api/expected/test_h5t/v114-18compat
@@ -1,0 +1,4 @@
+H5Tarray_create_vers = 2
+H5Tcommit_vers = 2
+H5Tget_array_dims_vers = 2
+H5Topen_vers = 2

--- a/api/expected/test_h5t/v114-18macro
+++ b/api/expected/test_h5t/v114-18macro
@@ -1,0 +1,4 @@
+H5Tarray_create_vers = 2
+H5Tcommit_vers = 2
+H5Tget_array_dims_vers = 2
+H5Topen_vers = 2

--- a/api/expected/test_h5t/v114-actual
+++ b/api/expected/test_h5t/v114-actual
@@ -1,0 +1,4 @@
+H5Tarray_create_vers = 2
+H5Tcommit_vers = 2
+H5Tget_array_dims_vers = 2
+H5Topen_vers = 2

--- a/api/expected/test_h5z/v114-110compat
+++ b/api/expected/test_h5z/v114-110compat
@@ -1,0 +1,1 @@
+H5Z_class_t_vers = 2

--- a/api/expected/test_h5z/v114-110macro
+++ b/api/expected/test_h5z/v114-110macro
@@ -1,0 +1,1 @@
+H5Z_class_t_vers = 2

--- a/api/expected/test_h5z/v114-112compat
+++ b/api/expected/test_h5z/v114-112compat
@@ -1,0 +1,1 @@
+H5Z_class_t_vers = 2

--- a/api/expected/test_h5z/v114-112macro
+++ b/api/expected/test_h5z/v114-112macro
@@ -1,0 +1,1 @@
+H5Z_class_t_vers = 2

--- a/api/expected/test_h5z/v114-16compat
+++ b/api/expected/test_h5z/v114-16compat
@@ -1,0 +1,1 @@
+H5Z_class_t_vers = 1

--- a/api/expected/test_h5z/v114-16macro
+++ b/api/expected/test_h5z/v114-16macro
@@ -1,0 +1,1 @@
+H5Z_class_t_vers = 1

--- a/api/expected/test_h5z/v114-18compat
+++ b/api/expected/test_h5z/v114-18compat
@@ -1,0 +1,1 @@
+H5Z_class_t_vers = 2

--- a/api/expected/test_h5z/v114-18macro
+++ b/api/expected/test_h5z/v114-18macro
@@ -1,0 +1,1 @@
+H5Z_class_t_vers = 2

--- a/api/expected/test_h5z/v114-actual
+++ b/api/expected/test_h5z/v114-actual
@@ -1,0 +1,1 @@
+H5Z_class_t_vers = 2

--- a/format/check_format.sh
+++ b/format/check_format.sh
@@ -52,6 +52,7 @@ fi
 
 # Define libraries to use
 h5ccdev="/mnt/scr1/pre-release/hdf5/vdev/$HOST_NAME/bin/h5cc"
+h5cc114="/mnt/scr1/pre-release/hdf5/v114/$HOST_NAME/bin/h5cc"
 h5cc112="/mnt/scr1/pre-release/hdf5/v112/$HOST_NAME/bin/h5cc"
 h5cc110="/mnt/scr1/pre-release/hdf5/v110/$HOST_NAME/bin/h5cc"
 h5cc18="/mnt/scr1/pre-release/hdf5/v18/$HOST_NAME/bin/h5cc"
@@ -87,6 +88,10 @@ if [ ! -x $h5cc110 ]; then
 fi
 if [ ! -x $h5cc112 ]; then
     echo "h5cc112($h5cc112) not found or not executable.  Abort"
+    exit 1
+fi
+if [ ! -x $h5cc114 ]; then
+    echo "h5cc114($h5cc114) not found or not executable.  Abort"
     exit 1
 fi
 if [ ! -x $h5ccdev ]; then
@@ -156,6 +161,22 @@ read112()
         ./a.out 2>/dev/null
     else
         echo "messed up compiling read_compat.c with v1.12"
+    fi
+}
+
+#### Read with v1.14 ####
+read114()
+{
+    $h5cc114 -DH5_USE_16_API read_compat.c
+    if [ $? -eq 0 ]
+    then
+        echo >> errors.log
+        echo >> errors.log
+        echo "========= Reading with v1.14 =========" >> errors.log
+        echo >> errors.log
+        ./a.out 2>/dev/null
+    else
+        echo "messed up compiling read_compat.c with v1.14"
     fi
 }
 
@@ -234,6 +255,22 @@ read_ref_compat_112()
         ./a.out 2>/dev/null
     else
         echo "messed up compiling read_ref_compat.c with v1.12"
+    fi
+}
+
+#### Read with v1.14 ####
+read_ref_compat_114()
+{
+    $h5cc114 -DH5_USE_16_API read_ref_compat.c
+    if [ $? -eq 0 ]
+    then
+        echo >> errors.log
+        echo >> errors.log
+        echo "========= Reading with v1.14 =========" >> errors.log
+        echo >> errors.log
+        ./a.out 2>/dev/null
+    else
+        echo "messed up compiling read_ref_compat.c with v1.14"
     fi
 }
 
@@ -350,6 +387,7 @@ RunTest()
     read18
     read110
     read112
+    read114
     readdev
     CheckErrors $1
     rm errors.log
@@ -379,6 +417,7 @@ Run_ref_compat_Test()
     read_ref_compat_18
     read_ref_compat_110
     read_ref_compat_112
+    read_ref_compat_114
     read_ref_compat_dev
     if [ "$CC" = "$h5cc18" -o "$CC" = "$h5cc110" ]; then
         CheckErrors $11

--- a/format/tests/expected/t_index_link-expected
+++ b/format/tests/expected/t_index_link-expected
@@ -106,6 +106,36 @@ Passed: group g5 (null)
 Passed: dset slink1 (through group g5)
 
 
+========= Reading with v1.14 =========
+
+Passed: file file (null)
+Passed: group g1 (null)
+Passed: group g1.1 (null)
+Passed: dset dset1 (null)
+Passed: data data1 (null)
+Passed: group g1.2 (null)
+Passed: dset hlink1 (null)
+Passed: group g2 (null)
+Passed: dtype dtype1 (null)
+Passed: group g3 (null)
+Passed: dset hlink2 (through group g3)
+Passed: group g4 (null)
+Passed: dset dset2 (through group g4)
+Passed: data data2 (null)
+Passed: attr attr00000 (null)
+Passed: attr attr00001 (null)
+Passed: attr attr00002 (null)
+Passed: attr attr00003 (null)
+Passed: attr attr00004 (null)
+Passed: attr attr00005 (null)
+Passed: attr attr00006 (null)
+Passed: attr attr00007 (null)
+Passed: attr attr00008 (null)
+Passed: attr attr00009 (null)
+Passed: group g5 (null)
+Passed: dset slink1 (through group g5)
+
+
 ========= Reading with vdev =========
 
 Passed: file file (null)

--- a/format/tests/expected/t_latest_mod_attr-expected
+++ b/format/tests/expected/t_latest_mod_attr-expected
@@ -118,6 +118,36 @@ Passed: group g5 (null)
 Passed: dset slink1 (through group g5)
 
 
+========= Reading with v1.14 =========
+
+Passed: file file (null)
+Passed: group g1 (null)
+Passed: group g1.1 (null)
+Passed: dset dset1 (null)
+Passed: data data1 (null)
+Passed: group g1.2 (null)
+Passed: dset hlink1 (null)
+Passed: group g2 (null)
+Passed: dtype dtype1 (null)
+Passed: group g3 (null)
+Passed: dset hlink2 (through group g3)
+Passed: group g4 (null)
+Passed: dset dset2 (through group g4)
+Passed: data data2 (null)
+Passed: attr attr00000 (null)
+Passed: attr attr00001 (null)
+Passed: attr attr00002 (null)
+Passed: attr attr00003 (null)
+Passed: attr attr00004 (null)
+Passed: attr attr00005 (null)
+Passed: attr attr00006 (null)
+Passed: attr attr00007 (null)
+Passed: attr attr00008 (null)
+Passed: attr attr00009 (null)
+Passed: group g5 (null)
+Passed: dset slink1 (through group g5)
+
+
 ========= Reading with vdev =========
 
 Passed: file file (null)

--- a/format/tests/expected/t_latest_mod_data-expected
+++ b/format/tests/expected/t_latest_mod_data-expected
@@ -118,6 +118,36 @@ Passed: group g5 (null)
 Passed: dset slink1 (through group g5)
 
 
+========= Reading with v1.14 =========
+
+Passed: file file (null)
+Passed: group g1 (null)
+Passed: group g1.1 (null)
+Passed: dset dset1 (null)
+Passed: data data1 (null)
+Passed: group g1.2 (null)
+Passed: dset hlink1 (null)
+Passed: group g2 (null)
+Passed: dtype dtype1 (null)
+Passed: group g3 (null)
+Passed: dset hlink2 (through group g3)
+Passed: group g4 (null)
+Passed: dset dset2 (through group g4)
+Passed: data data2 (null)
+Passed: attr attr00000 (null)
+Passed: attr attr00001 (null)
+Passed: attr attr00002 (null)
+Passed: attr attr00003 (null)
+Passed: attr attr00004 (null)
+Passed: attr attr00005 (null)
+Passed: attr attr00006 (null)
+Passed: attr attr00007 (null)
+Passed: attr attr00008 (null)
+Passed: attr attr00009 (null)
+Passed: group g5 (null)
+Passed: dset slink1 (through group g5)
+
+
 ========= Reading with vdev =========
 
 Passed: file file (null)

--- a/format/tests/expected/t_latest_more_groups-expected
+++ b/format/tests/expected/t_latest_more_groups-expected
@@ -118,6 +118,36 @@ Passed: group g5 (null)
 Passed: dset slink1 (through group g5)
 
 
+========= Reading with v1.14 =========
+
+Passed: file file (null)
+Passed: group g1 (null)
+Passed: group g1.1 (null)
+Passed: dset dset1 (null)
+Passed: data data1 (null)
+Passed: group g1.2 (null)
+Passed: dset hlink1 (null)
+Passed: group g2 (null)
+Passed: dtype dtype1 (null)
+Passed: group g3 (null)
+Passed: dset hlink2 (through group g3)
+Passed: group g4 (null)
+Passed: dset dset2 (through group g4)
+Passed: data data2 (null)
+Passed: attr attr00000 (null)
+Passed: attr attr00001 (null)
+Passed: attr attr00002 (null)
+Passed: attr attr00003 (null)
+Passed: attr attr00004 (null)
+Passed: attr attr00005 (null)
+Passed: attr attr00006 (null)
+Passed: attr attr00007 (null)
+Passed: attr attr00008 (null)
+Passed: attr attr00009 (null)
+Passed: group g5 (null)
+Passed: dset slink1 (through group g5)
+
+
 ========= Reading with vdev =========
 
 Passed: file file (null)

--- a/format/tests/expected/t_newatts-expected
+++ b/format/tests/expected/t_newatts-expected
@@ -118,6 +118,36 @@ Passed: group g5 (null)
 Passed: dset slink1 (through group g5)
 
 
+========= Reading with v1.14 =========
+
+Passed: file file (null)
+Passed: group g1 (null)
+Passed: group g1.1 (null)
+Passed: dset dset1 (null)
+Passed: data data1 (null)
+Passed: group g1.2 (null)
+Passed: dset hlink1 (null)
+Passed: group g2 (null)
+Passed: dtype dtype1 (null)
+Passed: group g3 (null)
+Passed: dset hlink2 (through group g3)
+Passed: group g4 (null)
+Passed: dset dset2 (through group g4)
+Passed: data data2 (null)
+Passed: attr attr00000 (null)
+Passed: attr attr00001 (null)
+Passed: attr attr00002 (null)
+Passed: attr attr00003 (null)
+Passed: attr attr00004 (null)
+Passed: attr attr00005 (null)
+Passed: attr attr00006 (null)
+Passed: attr attr00007 (null)
+Passed: attr attr00008 (null)
+Passed: attr attr00009 (null)
+Passed: group g5 (null)
+Passed: dset slink1 (through group g5)
+
+
 ========= Reading with vdev =========
 
 Passed: file file (null)

--- a/format/tests/expected/t_newdata-expected
+++ b/format/tests/expected/t_newdata-expected
@@ -107,6 +107,36 @@ Passed: group g5 (null)
 Passed: dset slink1 (through group g5)
 
 
+========= Reading with v1.14 =========
+
+Passed: file file (null)
+Passed: group g1 (null)
+Passed: group g1.1 (null)
+Passed: dset dset1 (null)
+Passed: data data1 (null)
+Passed: group g1.2 (null)
+Passed: dset hlink1 (null)
+Passed: group g2 (null)
+Passed: dtype dtype1 (null)
+Passed: group g3 (null)
+Passed: dset hlink2 (through group g3)
+Passed: group g4 (null)
+Passed: dset dset2 (through group g4)
+Passed: data data2 (null)
+Passed: attr attr00000 (null)
+Passed: attr attr00001 (null)
+Passed: attr attr00002 (null)
+Passed: attr attr00003 (null)
+Passed: attr attr00004 (null)
+Passed: attr attr00005 (null)
+Passed: attr attr00006 (null)
+Passed: attr attr00007 (null)
+Passed: attr attr00008 (null)
+Passed: attr attr00009 (null)
+Passed: group g5 (null)
+Passed: dset slink1 (through group g5)
+
+
 ========= Reading with vdev =========
 
 Passed: file file (null)

--- a/format/tests/expected/t_newfile-expected
+++ b/format/tests/expected/t_newfile-expected
@@ -93,6 +93,36 @@ Passed: group g5 (null)
 Passed: dset slink1 (through group g5)
 
 
+========= Reading with v1.14 =========
+
+Passed: file file (null)
+Passed: group g1 (null)
+Passed: group g1.1 (null)
+Passed: dset dset1 (null)
+Passed: data data1 (null)
+Passed: group g1.2 (null)
+Passed: dset hlink1 (null)
+Passed: group g2 (null)
+Passed: dtype dtype1 (null)
+Passed: group g3 (null)
+Passed: dset hlink2 (through group g3)
+Passed: group g4 (null)
+Passed: dset dset2 (through group g4)
+Passed: data data2 (null)
+Passed: attr attr00000 (null)
+Passed: attr attr00001 (null)
+Passed: attr attr00002 (null)
+Passed: attr attr00003 (null)
+Passed: attr attr00004 (null)
+Passed: attr attr00005 (null)
+Passed: attr attr00006 (null)
+Passed: attr attr00007 (null)
+Passed: attr attr00008 (null)
+Passed: attr attr00009 (null)
+Passed: group g5 (null)
+Passed: dset slink1 (through group g5)
+
+
 ========= Reading with vdev =========
 
 Passed: file file (null)

--- a/format/tests/expected/t_newgroup-expected
+++ b/format/tests/expected/t_newgroup-expected
@@ -106,6 +106,36 @@ Passed: group g5 (null)
 Passed: dset slink1 (through group g5)
 
 
+========= Reading with v1.14 =========
+
+Passed: file file (null)
+Passed: group g1 (null)
+Passed: group g1.1 (null)
+Passed: dset dset1 (null)
+Passed: data data1 (null)
+Passed: group g1.2 (null)
+Passed: dset hlink1 (null)
+Passed: group g2 (null)
+Passed: dtype dtype1 (null)
+Passed: group g3 (null)
+Passed: dset hlink2 (through group g3)
+Passed: group g4 (null)
+Passed: dset dset2 (through group g4)
+Passed: data data2 (null)
+Passed: attr attr00000 (null)
+Passed: attr attr00001 (null)
+Passed: attr attr00002 (null)
+Passed: attr attr00003 (null)
+Passed: attr attr00004 (null)
+Passed: attr attr00005 (null)
+Passed: attr attr00006 (null)
+Passed: attr attr00007 (null)
+Passed: attr attr00008 (null)
+Passed: attr attr00009 (null)
+Passed: group g5 (null)
+Passed: dset slink1 (through group g5)
+
+
 ========= Reading with vdev =========
 
 Passed: file file (null)

--- a/format/tests/expected/t_newlink-expected
+++ b/format/tests/expected/t_newlink-expected
@@ -118,6 +118,36 @@ Passed: group g5 (null)
 Passed: dset slink1 (through group g5)
 
 
+========= Reading with v1.14 =========
+
+Passed: file file (null)
+Passed: group g1 (null)
+Passed: group g1.1 (null)
+Passed: dset dset1 (null)
+Passed: data data1 (null)
+Passed: group g1.2 (null)
+Passed: dset hlink1 (null)
+Passed: group g2 (null)
+Passed: dtype dtype1 (null)
+Passed: group g3 (null)
+Passed: dset hlink2 (through group g3)
+Passed: group g4 (null)
+Passed: dset dset2 (through group g4)
+Passed: data data2 (null)
+Passed: attr attr00000 (null)
+Passed: attr attr00001 (null)
+Passed: attr attr00002 (null)
+Passed: attr attr00003 (null)
+Passed: attr attr00004 (null)
+Passed: attr attr00005 (null)
+Passed: attr attr00006 (null)
+Passed: attr attr00007 (null)
+Passed: attr attr00008 (null)
+Passed: attr attr00009 (null)
+Passed: group g5 (null)
+Passed: dset slink1 (through group g5)
+
+
 ========= Reading with vdev =========
 
 Passed: file file (null)

--- a/format/tests/expected/t_newtype-expected
+++ b/format/tests/expected/t_newtype-expected
@@ -117,6 +117,36 @@ Passed: group g5 (null)
 Passed: dset slink1 (through group g5)
 
 
+========= Reading with v1.14 =========
+
+Passed: file file (null)
+Passed: group g1 (null)
+Passed: group g1.1 (null)
+Passed: dset dset1 (null)
+Passed: data data1 (null)
+Passed: group g1.2 (null)
+Passed: dset hlink1 (null)
+Passed: group g2 (null)
+Passed: dtype dtype1 (null)
+Passed: group g3 (null)
+Passed: dset hlink2 (through group g3)
+Passed: group g4 (null)
+Passed: dset dset2 (through group g4)
+Passed: data data2 (null)
+Passed: attr attr00000 (null)
+Passed: attr attr00001 (null)
+Passed: attr attr00002 (null)
+Passed: attr attr00003 (null)
+Passed: attr attr00004 (null)
+Passed: attr attr00005 (null)
+Passed: attr attr00006 (null)
+Passed: attr attr00007 (null)
+Passed: attr attr00008 (null)
+Passed: attr attr00009 (null)
+Passed: group g5 (null)
+Passed: dset slink1 (through group g5)
+
+
 ========= Reading with vdev =========
 
 Passed: file file (null)

--- a/format/tests/expected/t_ref1-expected
+++ b/format/tests/expected/t_ref1-expected
@@ -30,6 +30,14 @@ Passed: Opening dataset Add_old_ref_object (null)
 Passed: Opening dataset Add_old_ref_region (null)
 
 
+========= Reading with v1.14 =========
+
+Passed: Opening dataset Old_ref_object (null)
+Passed: Opening dataset Old_ref_region (null)
+Passed: Opening dataset Add_old_ref_object (null)
+Passed: Opening dataset Add_old_ref_region (null)
+
+
 ========= Reading with vdev =========
 
 Passed: Opening dataset Old_ref_object (null)

--- a/format/tests/expected/t_ref2-expected
+++ b/format/tests/expected/t_ref2-expected
@@ -30,6 +30,14 @@ Passed: Opening dataset Add_revised_ref_object (null)
 Passed: Opening dataset Add_revised_ref_region (null)
 
 
+========= Reading with v1.14 =========
+
+Passed: Opening dataset Old_ref_object (null)
+Passed: Opening dataset Old_ref_region (null)
+Passed: Opening dataset Add_revised_ref_object (null)
+Passed: Opening dataset Add_revised_ref_region (null)
+
+
 ========= Reading with vdev =========
 
 Passed: Opening dataset Old_ref_object (null)

--- a/format/tests/t_ref.c
+++ b/format/tests/t_ref.c
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     int ret;                /* Return status */
 
 
-#if defined H5_USE_114_API_DEFAULT || H5_USE_112_API_DEFAULT
+#if defined H5_USE_116_API_DEFAULT || defined H5_USE_114_API_DEFAULT || H5_USE_112_API_DEFAULT
     H5R_ref_t wbuf[2];    /* buffer to write to disk          */
 #else
     hobj_ref_t wbuf_obj[2];
@@ -94,7 +94,7 @@ int main(int argc, char *argv[])
     coord1[8][0] = 97;
     coord1[9][0] = 03;
 
-#if defined H5_USE_114_API_DEFAULT || defined H5_USE_112_API_DEFAULT
+#if defined H5_USE_116_API_DEFAULT || defined H5_USE_114_API_DEFAULT || defined H5_USE_112_API_DEFAULT
 
     /* Create a dataset with object reference (with the revised reference type) */
     did1 = H5Dcreate2(fid,  ADD_REVISED_OBJ_NAME, H5T_STD_REF, sid_1_2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);


### PR DESCRIPTION
Add "if defined H5_USE_116_API_DEFAULT" condition to t_ref.c to get correct references for develop testing.
Add v114 tests.
Update develop version 1.13.0 to 1.15.0
Remove 1.13.x tests.